### PR TITLE
Adds package.json for devDependencies, build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# OS
+.DS_Store
+
+# Logs
+logs
+*.log*
+
+# Dependency directory
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,21 +10,24 @@ TypeScript is available on npm at https://www.npmjs.com/package/typescript
 
 ### Compiling
 
-First install [nodejs](https://nodejs.org/en/) which will by default include `npm`. Then install latest typescript compiler on system, using following `npm` command.
+First install [Node.js](https://nodejs.org/) which will by default include `npm`. Then, install the project dependencies, including the TypeScript compiler, using following command:
 
-```
-npm install --global typescript
+```sh
+npm install
 ```
 
-In the src folder of this project execute following command to compile. (current variablefont.js is generated using tsc version `2.5.3`).
+Don’t edit the `variableFont.js` file directly. It is generated using the TypeScript compiler, `tsc`. You can rebuild the file yourself by running the following command:
 
+```sh
+npm run build
 ```
-tsc
+
+This is a shortcut to running the build script defined in the `package.json` file. You can manually run it with:
+
+```sh
+npx tsc --project ./src/tsconfig.json
 ```
-OR
-```
-tsc --project ./tsconfig.json
-```
+
 The output file is `variablefont.js` in the root folder.
 
 ## How to modify the source for contribution
@@ -40,22 +43,20 @@ The output file is `variablefont.js` in the root folder.
     A dedicated branch for your pull request means you can develop multiple features at the same time, and ensures
     that your pull request is stable even if you later decide to develop an unrelated feature.
 
-4. Install typescript:
+4. Install dependencies:
 
-```
-npm install --global typescript
+```sh
+npm install
 ```
 
-5. Make some changes to the source files
+5. Make some changes to the source files in `src`
 
 6. Build variableFont.js
+
 ```
-tsc
+npm run build
 ```
-OR
-```
-tsc --project ./tsconfig.json
-```
+
 The output file is `variablefont.js` in the root folder.
 
 7. Test your changes in the demo program. Modify it if needed.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Simply save the folder locally then open VariableFontViewer.html in a compatible
 
 The demo page is also available for viewing at http://monotype.github.io/variableFont.js/demo/.
 
+## Getting started with script tags
+
+This project has a hard dependency on [opentype.js](https://github.com/nodebox/opentype.js). Please follow [instruction](https://github.com/nodebox/opentype.js#using-bower) on the opentype.js site to include it in your page. Opentype.js must be included before including variablefont.js in the html page. variableFont.js functions depend on opentype.js.
+
+## Getting started with npm
+
+If you are managing your project dependencies with npm, run the following command in your own project:
+
+```sh
+npm install --save variablefont.js opentype.js
+```
+
+This will install the variablefont.js and the required opentype.js peer dependency, and save those requirements to your `package.json` file.
+
 ## API:
 
 A global class `VariableFont` is made available when variablefont.js is added in a page. This class can be used to extend opentype.js Font object.
@@ -26,9 +40,3 @@ vf.getInstances(); // get instances field from fvar table.
 vf.getInstancesCount(); // get number of instances entries from fvar table.
 vf.getAxesCount(); // get number of axes entries from fvar table.
 ```
-
-
-## Dependency
-
-This project has a hard dependency on [opentype.js](https://github.com/nodebox/opentype.js). Please follow [instruction](https://github.com/nodebox/opentype.js#using-bower) on the opentype.js site to include it in your page. Opentype.js must be included before including variablefont.js in the html page. variableFont.js functions depend on opentype.js.
-

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "variablefont.js",
+  "version": "0.0.0",
+  "description": "Library for using Variable Fonts. Extends the functionality of OpenType.js.",
+  "main": "variableFont.js",
+  "author": "",
+  "repository": "https://github.com/monotype/variableFont.js.git",
+  "license": "MIT",
+  "peerDependencies": {
+    "opentype.js": "^0.8.0"
+  },
+  "devDependencies": {
+    "opentype.js": "^0.8.0",
+    "typescript": "2.5.3"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc --project ./src/tsconfig.json"
+  }
+}


### PR DESCRIPTION
Hello! Based on my experience going through the Contributing guide, I’m hoping this PR will help make it easier for other projects to install and contribute to this project.

- Adds `.gitignore` file
- Adds `package.json` so `devDependencies` (TypeScript), `peerDependencies` (opentype.js) can be recorded and handled by npm
- Makes it possible to publish the module to npm, so other projects can install it (will still need some coordination to make this happen, you will likely want to publish it under a Monotype org account)
- Updates the README and contributing guide so you don’t need to install TypeScript globally, and can just run `npm run build` now

From here you could still:

- [ ] Fill out [`author` in the `package.json`](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
- [ ] Set the [version number in the `package.json`](https://docs.npmjs.com/files/package.json#version)
- [ ] Consider changing the name everywhere to `variablefont.js` or `@monotype/variablefont`, because npm only supports lowercase letters now
- [ ] Publish it under a Monotype npm org account so others can `npm install`. You can give this a try already using the version I published to npm as a demo: `npm install @kennethormandy/variablefont`
- [ ] Consider updating the `npm run build` command with any other TypeScript tooling you are using, so it’s easier for people to have the output automatically generated rather than run a command for each change

If you’re looking for more recommendations on making it easier for other JavaScript-based projects to integrate this library, feel free to let me know.